### PR TITLE
chore: move @types dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
 		"normalize"
 	],
 	"dependencies": {
-		"@types/normalize-package-data": "^2.4.3",
 		"normalize-package-data": "^6.0.0",
 		"parse-json": "^8.0.0",
 		"type-fest": "^4.6.0",
 		"unicorn-magic": "^0.1.0"
 	},
 	"devDependencies": {
+		"@types/normalize-package-data": "^2.4.4",
 		"ava": "^5.3.1",
 		"tsd": "^0.29.0",
 		"xo": "^0.56.0"


### PR DESCRIPTION
Hey there! 👋

This PR moves `@types/normalize-package-data` into `devDependencies`, ensuring it won't be packaged after publishing.

I also noticed that a few other dependencies may need updates. If you'd like, I can open another PR to handle those too!